### PR TITLE
Load Lumo utility classes via @StyleSheet instead of CSS import

### DIFF
--- a/src/main/frontend/views/grocery/grocery-view.ts
+++ b/src/main/frontend/views/grocery/grocery-view.ts
@@ -1,4 +1,3 @@
-import '@vaadin/vaadin-lumo-styles/utility.css';
 import '@vaadin/button';
 import '@vaadin/text-field';
 import '@vaadin/number-field';

--- a/src/main/java/com/example/application/Application.java
+++ b/src/main/java/com/example/application/Application.java
@@ -1,8 +1,10 @@
 package com.example.application;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
@@ -16,6 +18,7 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
  */
 @SpringBootApplication
 @Theme(value = "hillagroceryapp")
+@StyleSheet(Lumo.UTILITY_STYLESHEET)
 @PWA(name = "Hilla Grocery App", shortName = "Hilla Grocery App", offlineResources = {"images/logo.png"})
 public class Application extends SpringBootServletInitializer implements AppShellConfigurator {
 


### PR DESCRIPTION
## Summary

- Remove `import '@vaadin/vaadin-lumo-styles/utility.css'` from `grocery-view.ts`
- Add `@StyleSheet(Lumo.UTILITY_STYLESHEET)` to `Application.java`
- The CSS side-effect import has no TypeScript type declarations, causing TS2882 in the Vite 8 production build
- `@StyleSheet` loads the same utility classes from the server side and works with both 25.1 and 25.2

Fixes #133
